### PR TITLE
Various improvements to integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.idea/
+integration-test/target/
 *.class
 *.log
+*.iml

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -155,22 +155,6 @@
               </arguments>
             </configuration>
           </execution>
-          <execution>
-            <!-- TODO: Remove this hack once upstream is fixed by SPARK-22777 -->
-            <id>set-exec-bit-on-docker-entrypoint-sh</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <workingDirectory>${project.build.directory}/spark-distro/dockerfiles</workingDirectory>
-              <executable>/bin/chmod</executable>
-              <arguments>
-                <argument>+x</argument>
-                <argument>spark-base/entrypoint.sh</argument>
-              </arguments>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -135,7 +135,7 @@
               <executable>/bin/sh</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>rm -rf spark-distro; mkdir spark-distro; mkdir spark-distro-tmp; cd spark-distro-tmp; tar xfz ${spark-distro-tgz}; mv * ../spark-distro; cd ..; rm -rf spark-distro-tmp</argument>
+                <argument>rm -rf spark-distro; mkdir spark-distro-tmp; cd spark-distro-tmp; tar xfz ${spark-distro-tgz}; mv * ../spark-distro; cd ..; rm -rf spark-distro-tmp</argument>
               </arguments>
             </configuration>
           </execution>
@@ -244,88 +244,7 @@
         </executions>
       </plugin>
     </plugins>
+
   </build>
-  <profiles>
-    <profile>
-      <id>v2</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>net.alchim31.maven</groupId>
-            <artifactId>scala-maven-plugin</artifactId>
-            <version>${scala-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>compile</goal>
-                  <goal>testCompile</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>${exec-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>unpack-spark-distro</id>
-                <phase>pre-integration-test</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <workingDirectory>${project.build.directory}</workingDirectory>
-                  <executable>/bin/sh</executable>
-                  <arguments>
-                    <argument>-c</argument>
-                    <argument>rm -rf spark-distro; mkdir spark-distro; mkdir spark-distro-tmp; cd spark-distro-tmp; tar xfz ${spark-distro-tgz}; mv * ../spark-distro; cd ..; rm -rf spark-distro-tmp</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <!-- Triggers scalatest plugin in the integration-test phase instead of
-                 the test phase. -->
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest-maven-plugin</artifactId>
-            <version>${scalatest-maven-plugin.version}</version>
-            <configuration>
-              <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-              <junitxml>.</junitxml>
-              <filereports>SparkTestSuite.txt</filereports>
-              <argLine>-ea -Xmx3g -XX:ReservedCodeCacheSize=512m ${extraScalaTestArgs}</argLine>
-              <stderr/>
-              <systemProperties>
-                <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
-                <java.awt.headless>true</java.awt.headless>
-              </systemProperties>
-              <tagsToExclude>${test.exclude.tags}</tagsToExclude>
-            </configuration>
-            <executions>
-              <execution>
-                <id>test</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <configuration>
-                  <!-- The negative pattern below prevents integration tests such as
-                       KubernetesSuite from running in the test phase. -->
-                  <suffixes>(?&lt;!Suite)</suffixes>
-                </configuration>
-              </execution>
-              <execution>
-                <id>integration-test</id>
-                <phase>integration-test</phase>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+
 </project>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -135,7 +135,7 @@
               <executable>/bin/sh</executable>
               <arguments>
                 <argument>-c</argument>
-                <argument>rm -rf spark-distro; mkdir spark-distro-tmp; cd spark-distro-tmp; tar xfz ${spark-distro-tgz}; mv * ../spark-distro; cd ..; rm -rf spark-distro-tmp</argument>
+                <argument>rm -rf spark-distro; mkdir spark-distro; mkdir spark-distro-tmp; cd spark-distro-tmp; tar xfz ${spark-distro-tgz}; mv * ../spark-distro; cd ..; rm -rf spark-distro-tmp</argument>
               </arguments>
             </configuration>
           </execution>
@@ -244,7 +244,88 @@
         </executions>
       </plugin>
     </plugins>
-
   </build>
-
+  <profiles>
+    <profile>
+      <id>v2</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <version>${scala-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>compile</goal>
+                  <goal>testCompile</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>${exec-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>unpack-spark-distro</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <workingDirectory>${project.build.directory}</workingDirectory>
+                  <executable>/bin/sh</executable>
+                  <arguments>
+                    <argument>-c</argument>
+                    <argument>rm -rf spark-distro; mkdir spark-distro; mkdir spark-distro-tmp; cd spark-distro-tmp; tar xfz ${spark-distro-tgz}; mv * ../spark-distro; cd ..; rm -rf spark-distro-tmp</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <!-- Triggers scalatest plugin in the integration-test phase instead of
+                 the test phase. -->
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-maven-plugin</artifactId>
+            <version>${scalatest-maven-plugin.version}</version>
+            <configuration>
+              <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+              <junitxml>.</junitxml>
+              <filereports>SparkTestSuite.txt</filereports>
+              <argLine>-ea -Xmx3g -XX:ReservedCodeCacheSize=512m ${extraScalaTestArgs}</argLine>
+              <stderr/>
+              <systemProperties>
+                <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
+                <java.awt.headless>true</java.awt.headless>
+              </systemProperties>
+              <tagsToExclude>${test.exclude.tags}</tagsToExclude>
+            </configuration>
+            <executions>
+              <execution>
+                <id>test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <!-- The negative pattern below prevents integration tests such as
+                       KubernetesSuite from running in the test phase. -->
+                  <suffixes>(?&lt;!Suite)</suffixes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>integration-test</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/integration-test/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/integration-test/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -58,14 +58,10 @@ private[spark] class KubernetesSuite extends FunSuite with BeforeAndAfterAll wit
   }
 
   test("Run SparkPi with no resources") {
-    assume(testBackend.name == MINIKUBE_TEST_BACKEND)
-
     runSparkPiAndVerifyCompletion()
   }
 
   test("Run SparkPi with a very long application name.") {
-    assume(testBackend.name == MINIKUBE_TEST_BACKEND)
-
     sparkAppConf.set("spark.app.name", "long" * 40)
     runSparkPiAndVerifyCompletion()
   }


### PR DESCRIPTION
Removed the MINIKUBE_TEST_BACKEND requirements for the SparkPI tests and some deprecated info.

Verified running on cloud with:
```
mvn clean -Ddownload.plugin.skip=true integration-test  \
-Dspark-distro-tgz=/home/ramanathana/go-workspace/src/apache-spark-on-k8s/release/spark/dist/spark.tar.gz  \
-Dspark-dockerfiles-dir=/home/ramanathana/go-workspace/src/apache-spark-on-k8s/release/spark/dist/kubernetes/dockerfiles \
-DextraScalaTestArgs="-Dspark.kubernetes.test.master=k8s://https://... -Dspark.docker.test.driverImage=spark-driver -Dspark.docker.test.executorImage=spark-executor"
```

cc/ @kimoonkim @mccheah @liyinan926 