### PR TITLE
Re-enabled tests using a non-minikube cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ Reuse this tarball to save a significant amount of time if you are iterating on 
 * `--namespace <namespace>` - set `<namespace>` to the namespace in which the tests should be run.
 * `--service-account <service account name>` - set `<service account name>` to the name of the Kubernetes service account to
 use in the namespace specified by the `--namespace`. The service account is expected to have permissions to get, list, watch,
-and create pods. A reference RBAC configuration is provided in `dev/spark-rbac.yaml`.
+and create pods. For clusters with RBAC turned on, it's important that the right permissions are granted to the service account
+in the namespace through an appropriate role and role binding. A reference RBAC configuration is provided in `dev/spark-rbac.yaml`.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,10 @@ source code has to be compiled.
 
 When the tests are cloning a repository and building it, the Spark distribution is placed in `target/spark/spark-<VERSION>.tgz`.
 Reuse this tarball to save a significant amount of time if you are iterating on the development of these integration tests.
+
+## Customizing the Namespace and Service Account
+
+* `--namespace <namespace>` - set `<namespace>` to the namespace in which the tests should be run.
+* `--service-account <service account name>` - set `<service account name>` to the name of the Kubernetes service account to
+use in the namespace specified by the `--namespace`. The service account is expected to have permissions to get, list, watch,
+and create pods. A reference RBAC configuration is provided in `dev/spark-rbac.yaml`.

--- a/dev/dev-run-integration-tests.sh
+++ b/dev/dev-run-integration-tests.sh
@@ -26,6 +26,8 @@ IMAGE_REPO="docker.io/kubespark"
 SPARK_TGZ="N/A"
 IMAGE_TAG="N/A"
 SPARK_MASTER=
+NAMESPACE=
+SERVICE_ACCOUNT=
 
 # Parse arguments
 while (( "$#" )); do
@@ -54,6 +56,18 @@ while (( "$#" )); do
       SPARK_TGZ="$2"
       shift
       ;;
+    --spark-master)
+      SPARK_MASTER="$2"
+      shift
+      ;;
+    --namespace)
+      NAMESPACE="$2"
+      shift
+      ;;
+    --service-account)
+      SERVICE_ACCOUNT="$2"
+      shift
+      ;;
     *)
       break
       ;;
@@ -68,13 +82,13 @@ then
   # clone spark distribution if needed.
   if [ -d "$SPARK_REPO_LOCAL_DIR" ];
   then
-    (cd $SPARK_REPO_LOCAL_DIR && git fetch origin $branch);
+    (cd $SPARK_REPO_LOCAL_DIR && git fetch origin $BRANCH);
   else
     mkdir -p $SPARK_REPO_LOCAL_DIR;
     git clone -b $BRANCH --single-branch $SPARK_REPO $SPARK_REPO_LOCAL_DIR;
   fi
   cd $SPARK_REPO_LOCAL_DIR
-  git checkout -B $BRANCH origin/$branch
+  git checkout -B $BRANCH origin/$BRANCH
   ./dev/make-distribution.sh --tgz -Phadoop-2.7 -Pkubernetes -DskipTests;
   SPARK_TGZ=$(find $SPARK_REPO_LOCAL_DIR -name spark-*.tgz)
   echo "Built Spark TGZ at $SPARK_TGZ".
@@ -83,18 +97,26 @@ fi
 
 cd $TEST_ROOT_DIR
 
-if [ -z $SPARK_MASTER ];
+properties=(
+  -Dspark.kubernetes.test.sparkTgz=$SPARK_TGZ \
+  -Dspark.kubernetes.test.imageTag=$IMAGE_TAG \
+  -Dspark.kubernetes.test.imageRepo=$IMAGE_REPO \
+  -Dspark.kubernetes.test.deployMode=$DEPLOY_MODE
+)
+
+if [ -n $NAMESPACE ];
 then
-  build/mvn integration-test \
-    -Dspark.kubernetes.test.sparkTgz=$SPARK_TGZ \
-    -Dspark.kubernetes.test.imageTag=$IMAGE_TAG \
-    -Dspark.kubernetes.test.imageRepo=$IMAGE_REPO \
-    -Dspark.kubernetes.test.deployMode=$DEPLOY_MODE;
-else
-  build/mvn integration-test \
-    -Dspark.kubernetes.test.sparkTgz=$SPARK_TGZ \
-    -Dspark.kubernetes.test.imageTag=$IMAGE_TAG \
-    -Dspark.kubernetes.test.imageRepo=$IMAGE_REPO \
-    -Dspark.kubernetes.test.deployMode=$DEPLOY_MODE \
-    -Dspark.kubernetes.test.master=$SPARK_MASTER;
+  properties=( ${properties[@]} -Dspark.kubernetes.test.namespace=$NAMESPACE )
 fi
+
+if [ -n $SERVICE_ACCOUNT ];
+then
+  properties=( ${properties[@]} -Dspark.kubernetes.test.serviceAccountName=$SERVICE_ACCOUNT )
+fi
+
+if [ -n $SPARK_MASTER ];
+then
+  properties=( ${properties[@]} -Dspark.kubernetes.test.master=$SPARK_MASTER )
+fi
+
+build/mvn integration-test ${properties[@]}

--- a/dev/spark-rbac.yaml
+++ b/dev/spark-rbac.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spark
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-sa
+  namespace: spark
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: spark-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: spark-role-binding
+subjects:
+- kind: ServiceAccount
+  name: spark-sa
+  namespace: spark
+roleRef:
+  kind: ClusterRole
+  name: spark-role
+  apiGroup: rbac.authorization.k8s.io

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,9 @@
             <spark.kubernetes.test.imageTagFile>${spark.kubernetes.test.imageTagFile}</spark.kubernetes.test.imageTagFile>
             <spark.kubernetes.test.unpackSparkDir>${spark.kubernetes.test.unpackSparkDir}</spark.kubernetes.test.unpackSparkDir>
             <spark.kubernetes.test.imageRepo>${spark.kubernetes.test.imageRepo}</spark.kubernetes.test.imageRepo>
+            <spark.kubernetes.test.master>${spark.kubernetes.test.master}</spark.kubernetes.test.master>
+            <spark.kubernetes.test.namespace>${spark.kubernetes.test.namespace}</spark.kubernetes.test.namespace>
+            <spark.kubernetes.test.serviceAccountName>${spark.kubernetes.test.serviceAccountName}</spark.kubernetes.test.serviceAccountName>
           </systemProperties>
           <tagsToExclude>${test.exclude.tags}</tagsToExclude>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,7 @@
             <spark.kubernetes.test.imageTagFile>${spark.kubernetes.test.imageTagFile}</spark.kubernetes.test.imageTagFile>
             <spark.kubernetes.test.unpackSparkDir>${spark.kubernetes.test.unpackSparkDir}</spark.kubernetes.test.unpackSparkDir>
             <spark.kubernetes.test.imageRepo>${spark.kubernetes.test.imageRepo}</spark.kubernetes.test.imageRepo>
+            <spark.kubernetes.test.deployMode>${spark.kubernetes.test.deployMode}</spark.kubernetes.test.deployMode>
             <spark.kubernetes.test.master>${spark.kubernetes.test.master}</spark.kubernetes.test.master>
             <spark.kubernetes.test.namespace>${spark.kubernetes.test.namespace}</spark.kubernetes.test.namespace>
             <spark.kubernetes.test.serviceAccountName>${spark.kubernetes.test.serviceAccountName}</spark.kubernetes.test.serviceAccountName>

--- a/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/GCE/GCETestBackend.scala
+++ b/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/GCE/GCETestBackend.scala
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
 
 import org.apache.spark.deploy.k8s.integrationtest.Utils
 import org.apache.spark.deploy.k8s.integrationtest.backend.IntegrationTestBackend
-import org.apache.spark.deploy.k8s.integrationtest.config._
 
 private[spark] class GCETestBackend(val master: String) extends IntegrationTestBackend {
   private var defaultClient: DefaultKubernetesClient = _
@@ -33,7 +32,7 @@ private[spark] class GCETestBackend(val master: String) extends IntegrationTestB
     defaultClient = new DefaultKubernetesClient(k8sConf)
   }
 
-  override def getKubernetesClient(): DefaultKubernetesClient = {
+  override def getKubernetesClient: DefaultKubernetesClient = {
     defaultClient
   }
 }

--- a/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/GCE/GCETestBackend.scala
+++ b/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/GCE/GCETestBackend.scala
@@ -21,13 +21,16 @@ import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
 import org.apache.spark.deploy.k8s.integrationtest.Utils
 import org.apache.spark.deploy.k8s.integrationtest.backend.IntegrationTestBackend
 
-private[spark] class GCETestBackend(val master: String) extends IntegrationTestBackend {
+private[spark] class GCETestBackend() extends IntegrationTestBackend {
+
   private var defaultClient: DefaultKubernetesClient = _
 
   override def initialize(): Unit = {
+    val masterUrl = Option(System.getProperty("spark.kubernetes.test.master"))
+      .getOrElse(throw new RuntimeException("Kubernetes master URL is not set"))
     val k8sConf = new ConfigBuilder()
       .withApiVersion("v1")
-      .withMasterUrl(Utils.checkAndGetK8sMasterUrl(master).replaceFirst("k8s://", ""))
+      .withMasterUrl(Utils.checkAndGetK8sMasterUrl(masterUrl).replaceFirst("k8s://", ""))
       .build()
     defaultClient = new DefaultKubernetesClient(k8sConf)
   }

--- a/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
+++ b/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.k8s.integrationtest.backend
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient
 
-import org.apache.spark.deploy.k8s.integrationtest.backend.GCE.GCETestBackend
+import org.apache.spark.deploy.k8s.integrationtest.backend.cloud.CloudTestBackend
 import org.apache.spark.deploy.k8s.integrationtest.backend.minikube.MinikubeTestBackend
 
 private[spark] trait IntegrationTestBackend {
@@ -35,7 +35,7 @@ private[spark] object IntegrationTestBackendFactory {
     if (deployMode == "minikube") {
       MinikubeTestBackend
     } else {
-      new GCETestBackend()
+      CloudTestBackend
     }
   }
 }

--- a/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
+++ b/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
@@ -30,8 +30,12 @@ private[spark] trait IntegrationTestBackend {
 
 private[spark] object IntegrationTestBackendFactory {
   def getTestBackend: IntegrationTestBackend = {
-    Option(System.getProperty("spark.kubernetes.test.master"))
-      .map(new GCETestBackend(_))
-      .getOrElse(MinikubeTestBackend)
+    val deployMode = Option(System.getProperty("spark.kubernetes.test.deployMode"))
+      .getOrElse("minikube")
+    if (deployMode == "minikube") {
+      MinikubeTestBackend
+    } else {
+      new GCETestBackend()
+    }
   }
 }

--- a/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
+++ b/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
@@ -29,7 +29,7 @@ private[spark] trait IntegrationTestBackend {
 }
 
 private[spark] object IntegrationTestBackendFactory {
-  def getTestBackend(): IntegrationTestBackend = {
+  def getTestBackend: IntegrationTestBackend = {
     Option(System.getProperty("spark.kubernetes.test.master"))
       .map(new GCETestBackend(_))
       .getOrElse(MinikubeTestBackend)

--- a/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/CloudTestBackend.scala
+++ b/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/CloudTestBackend.scala
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.deploy.k8s.integrationtest.backend.GCE
+package org.apache.spark.deploy.k8s.integrationtest.backend.cloud
 
 import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
 
 import org.apache.spark.deploy.k8s.integrationtest.Utils
 import org.apache.spark.deploy.k8s.integrationtest.backend.IntegrationTestBackend
 
-private[spark] class GCETestBackend() extends IntegrationTestBackend {
+private[spark] object CloudTestBackend extends IntegrationTestBackend {
 
   private var defaultClient: DefaultKubernetesClient = _
 

--- a/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/MinikubeTestBackend.scala
+++ b/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/MinikubeTestBackend.scala
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient
 import org.apache.spark.deploy.k8s.integrationtest.backend.IntegrationTestBackend
 
 private[spark] object MinikubeTestBackend extends IntegrationTestBackend {
+
   private var defaultClient: DefaultKubernetesClient = _
 
   override def initialize(): Unit = {


### PR DESCRIPTION
Tested manually.

```
dev/dev-run-integration-tests.sh --spark-tgz ~/spark-2.4.0-SNAPSHOT-bin-2.7.3.tgz --image-repo liyinan926 --deploy-mode cloud --spark-master k8s://https://$MASTER_IP --namespace spark --service-account spark-sa

KubernetesSuite:
- Run SparkPi with no resources
- Run SparkPi with a very long application name.
- Run SparkPi with a master URL without a scheme.
- Run SparkPi with an argument.
- Run SparkPi with custom driver pod name, labels, annotations, and environment variables.
- Run SparkPi with a test secret mounted into the driver and executor pods
- Run PageRank using remote data file
- Run PageRank using remote data file with test secret mounted into the driver and executors
```

@mccheah @foxish @kimoonkim