### PR TITLE
Create RBAC role for tests to run on 1.8+ clusters

### DIFF
--- a/e2e/e2e-prow.sh
+++ b/e2e/e2e-prow.sh
@@ -59,7 +59,7 @@ properties=(
 
 # Run tests.
 echo "Starting test with ${properties[@]}"
-build/mvn integration-test "${properties[@]}"
+build/mvn integration-test "${properties[@]}" || :
 
 # Copy out the junit xml files for consumption by k8s test-infra.
 ls -1 ./target/surefire-reports/*.xml | cat -n | while read n f; do cp "$f" "/workspace/_artifacts/junit_0$n.xml"; done

--- a/e2e/e2e-prow.sh
+++ b/e2e/e2e-prow.sh
@@ -53,9 +53,13 @@ properties=(
   -Dspark.kubernetes.test.imageRepo=$IMAGE_REPO \
   -Dspark.kubernetes.test.sparkTgz="$SPARK_TGZ" \
   -Dspark.kubernetes.test.deployMode=cloud \
-  -Dspark.kubernetes.test.namespace=default \
-  -Dspark.kubernetes.test.serviceAccountName=default
+  -Dspark.kubernetes.test.namespace=spark \
+  -Dspark.kubernetes.test.serviceAccountName=spark-sa
 )
+
+# Run kubectl commands and create appropriate roles
+kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
+kubectl create -f ./dev/spark-rbac.yaml
 
 # Run tests.
 echo "Starting test with ${properties[@]}"


### PR DESCRIPTION
Changes here:

- Change svc account and namespace to run tests in.
- Ensure that failing the maven test phase doesn't exit the script before the logs are copied over.

This should fix the latest-gke tests under https://k8s-testgrid.appspot.com/sig-big-data#spark-periodic-latest-gke

cc @liyinan926 